### PR TITLE
[Fix] 절대음감 컨텐츠에 충돌 적용 안되는 문제 해결

### DIFF
--- a/Assets/Resources/OVRCameraRig.prefab
+++ b/Assets/Resources/OVRCameraRig.prefab
@@ -3945,7 +3945,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2688028180536851184}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.4, z: 0}
+  m_LocalPosition: {x: 0, y: -0.7, z: 0}
   m_LocalScale: {x: 0.7, y: 0.6, z: 0.7}
   m_Children: []
   m_Father: {fileID: 8195805791958539739}


### PR DESCRIPTION
OVRCameraRig에 달려있는 BodyCollider의 y축 위치 -0.4 -> -0.7로 조정