### PR TITLE
[Fix] Online여부가 적용되지 않던 문제 해결

### DIFF
--- a/Assets/_Scripts/StartRoom/LobbyChanger.cs
+++ b/Assets/_Scripts/StartRoom/LobbyChanger.cs
@@ -172,10 +172,10 @@ public class LobbyChanger : MonoBehaviourPunCallbacks
     {
         base.OnDisconnected(cause);
         
-            MySqlSetting.UpdateValueByBase(Asset.EaccountdbColumns.Nickname, PhotonNetwork.NickName, Asset.EaccountdbColumns.IsOnline, 0);
+         MySqlSetting.UpdateValueByBase(Asset.EaccountdbColumns.Nickname, PhotonNetwork.NickName, Asset.EaccountdbColumns.IsOnline, 0);
 
-        
     }
+
 
     public override void OnJoinRoomFailed(short returnCode, string message)
     {
@@ -188,6 +188,14 @@ public class LobbyChanger : MonoBehaviourPunCallbacks
         {
             Debug.Log("[LogOut] LobbyChanger OnJoinRoomFailed, Reconnecting with same name");
             PhotonNetwork.JoinOrCreateRoom(_nextSceneRoomName, _nextRoomOption, TypedLobby.Default);
+        }
+    }
+
+    private void OnApplicationQuit()
+    {
+        if(MySqlSetting.IsPlayerOnline(PhotonNetwork.NickName))
+        {
+            MySqlSetting.UpdateValueByBase(Asset.EaccountdbColumns.Nickname, PhotonNetwork.NickName, Asset.EaccountdbColumns.IsOnline, 0);
         }
     }
 }


### PR DESCRIPTION
- LobbyChanger의 OnApplicationQuit에서 IsOnline이 바뀌지 않았으면 오프라인으로 바꿔줌