### PR TITLE
[Fix] 오크통의 PhotonView 설정변경 / 로비1 아레나 경비병 이름 부여

### DIFF
--- a/Assets/_Prefabs/OakBarrel/OakBarrel.prefab
+++ b/Assets/_Prefabs/OakBarrel/OakBarrel.prefab
@@ -131,7 +131,7 @@ MonoBehaviour:
   Group: 0
   prefixField: -1
   Synchronization: 3
-  OwnershipTransfer: 0
+  OwnershipTransfer: 1
   observableSearch: 2
   ObservedComponents: []
   sceneViewId: 0


### PR DESCRIPTION
오크통의 PhotonView Ownership Transfer 를 Takeover로 변경
로비1 아레나 경비병 이름 부여했으나 폰트깨짐
로비1 하이어라키 정리 (투기장, 로비2, 시작의방 이동 NPC 들 부모 변경)