### PR TITLE
[Fix] 펫 이동 로직 수정, 펫 생성 관련 로직 수정

### DIFF
--- a/Assets/Resources/FantasyLobbyPlayer.prefab
+++ b/Assets/Resources/FantasyLobbyPlayer.prefab
@@ -15,6 +15,14 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1822357777904590069, guid: 6d93b18d69efc4746b3192b51cf27e61, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822357777904590069, guid: 6d93b18d69efc4746b3192b51cf27e61, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.5
+      objectReference: {fileID: 0}
     - target: {fileID: 6072405480879903498, guid: 6d93b18d69efc4746b3192b51cf27e61, type: 3}
       propertyPath: m_Name
       value: FantasyLobbyPlayer

--- a/Assets/Resources/Lobby2Player.prefab
+++ b/Assets/Resources/Lobby2Player.prefab
@@ -4738,7 +4738,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 195082498324664529, guid: 5701f0d0639f86d489bf713708f7a39d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 195082498324664529, guid: 5701f0d0639f86d489bf713708f7a39d, type: 3}
       propertyPath: m_LocalPosition.y
@@ -4746,7 +4746,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 195082498324664529, guid: 5701f0d0639f86d489bf713708f7a39d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 195082498324664529, guid: 5701f0d0639f86d489bf713708f7a39d, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Resources/NewPlayer.prefab
+++ b/Assets/Resources/NewPlayer.prefab
@@ -3655,6 +3655,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cd7526bc14b4c6049acc0233d852dcae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _audioSource: {fileID: 0}
+  _drinkSound: {fileID: 0}
 --- !u!114 &4823571551503449014
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4436,6 +4438,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _playerOakBarrel: {fileID: 160640417621920002}
   _playerModel: {fileID: 4097230144943633450}
+  _inOakBarrelSound: {fileID: 0}
 --- !u!1 &6718035182797435399
 GameObject:
   m_ObjectHideFlags: 0
@@ -4694,7 +4697,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 195082498324664529, guid: 5701f0d0639f86d489bf713708f7a39d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 195082498324664529, guid: 5701f0d0639f86d489bf713708f7a39d, type: 3}
       propertyPath: m_LocalPosition.y
@@ -4702,7 +4705,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 195082498324664529, guid: 5701f0d0639f86d489bf713708f7a39d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 195082498324664529, guid: 5701f0d0639f86d489bf713708f7a39d, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/_Prefabs/Pets/PetSpawner.prefab
+++ b/Assets/_Prefabs/Pets/PetSpawner.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 195082498324664529}
   - component: {fileID: 195082498324664530}
   - component: {fileID: 195082498324664528}
+  - component: {fileID: 3882409040354053179}
   m_Layer: 0
   m_Name: PetSpawner
-  m_TagString: Untagged
+  m_TagString: PetSpawner
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -26,7 +27,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195082498324664531}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.2961453, y: 0.6071453, z: -1.6032858}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -46,11 +47,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _petData: {fileID: 11400000, guid: 01e67c6a783c3f749baf213db99f3619, type: 2}
   _petObject: {fileID: 0}
-  _petMaxExpType: 0
-  _petLevel: 0
-  _petExp: 0
-  _petMaxExp: 0
-  _petSize: 0
 --- !u!114 &195082498324664528
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -73,3 +69,16 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &3882409040354053179
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 195082498324664531}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 2.5, y: 0.5, z: 2.5}

--- a/Assets/_Scripts/LobbyAll/Pet/Pet.cs
+++ b/Assets/_Scripts/LobbyAll/Pet/Pet.cs
@@ -40,7 +40,6 @@ public class Pet : MonoBehaviourPunCallbacks
             if (_petData.Status[i] == EPetStatus.EQUIPED)
             {
                 _eqiupNum = i;
-                Debug.Log("[PET] " + _eqiupNum);
                 break;
             }
         }

--- a/Assets/_Scripts/LobbyAll/Pet/PetLODMove.cs
+++ b/Assets/_Scripts/LobbyAll/Pet/PetLODMove.cs
@@ -29,7 +29,7 @@ public class PetLODMove : PetMove
     {
         foreach (Animator animator in _animators)
         {
-            animator.SetBool("IsWalk", isMove);
+            animator.SetBool(PARAM_IS_WALK, isMove);
         }
 
         ChangeMoveStateHelper(isMove);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -36,6 +36,7 @@ TagManager:
   - IceWizard
   - FireWizard
   - Rock_Golem
+  - PetSpawner
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- 펫 이동을 위한 목적지 설정을 PetSpawner의 Transform으로 하였으나, 로컬 좌표에 고정되어 버리는 문제가 발생하여 그 root인 Player의 Transform으로 하는 것으로 수정
- 트래킹을 멈추는 것은 PetSpawner의 콜라이더에 충돌할 때로 로직 수정
- 펫 생성 함수를 IsMine으로 본인 소유의 펫 스포너만 동작하도록 수정